### PR TITLE
Update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/check-badges.yml
+++ b/.github/workflows/check-badges.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Check badges in README.md
       run: ./scripts/check-badges.bash "README.md"

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -26,14 +26,14 @@ jobs:
     continue-on-error: true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup latest version of dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
     - name: Build with latest version
       run: dotnet build --warnaserror Aspose.BarCode.Cloud.Sdk.sln
 
     - name: Setup ${{ matrix.dotnet-version }} version of dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
 

--- a/.github/workflows/net-framework.yml
+++ b/.github/workflows/net-framework.yml
@@ -26,18 +26,18 @@ jobs:
     continue-on-error: true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup .NET 10 SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '10.0.x'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.1
+      uses: microsoft/setup-msbuild@v3
 
     - name: Setup VSTest
-      uses: darenm/Setup-VSTest@v1.2
+      uses: darenm/Setup-VSTest@v1.3
 
     - name: Pack nuget
       run: |

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build the Docker image
       run: docker build . --file Dockerfile

--- a/.github/workflows/test-examples-and-snippets.yml
+++ b/.github/workflows/test-examples-and-snippets.yml
@@ -12,9 +12,9 @@ jobs:
     
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup latest version of dotnet
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
     - name: Build nuget with latest version
       run: |
          ./scripts/pack-nuget.bash


### PR DESCRIPTION
## Summary
- GitHub is deprecating Node 20 on Actions runners (EOL April 2026, removal Fall 2026)
- Updated all actions to their latest major versions with Node 24 runtime support
- actions/checkout v4 → v6
- actions/setup-dotnet v4 → v5
- microsoft/setup-msbuild v1.1 → v3
- darenm/Setup-VSTest v1.2 → v1.3

## Test plan
- [ ] .NET Core Linux workflow passes
- [ ] .NET Framework Windows workflow passes
- [ ] Pack workflow passes