### PR TITLE
Trim trailing empty line from README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ format:
 format-doc:
 	# Remove trailing white space
 	find . -iname "*.md" -exec sed -i -e 's_[[:space:]]*$$__' {} \;
+	# Trim trailing empty line
+	sed -i -e '$${/^$$/d;}' README.md
 
 .PHONY: test
 test: nuget


### PR DESCRIPTION
## Summary
- Enhance `format-doc` target to trim trailing empty line from README.md

## Test plan
- [ ] Verify `make format-doc` runs successfully
- [ ] Verify README.md has no trailing empty line after generation